### PR TITLE
server: handleFieldList handle null terminated table name

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"runtime"
+	"strings"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/arena"
@@ -361,7 +362,12 @@ func (cc *ClientConn) handleQuery(sql string) (err error) {
 }
 
 func (cc *ClientConn) handleFieldList(sql string) (err error) {
-	columns, err := cc.ctx.FieldList(sql, "")
+	parts := strings.Split(sql, "\x00")
+	wildCard := ""
+	if len(parts) == 2 {
+		wildCard = parts[1]
+	}
+	columns, err := cc.ctx.FieldList(parts[0], wildCard)
 	if err != nil {
 		return
 	}

--- a/server/conn.go
+++ b/server/conn.go
@@ -363,11 +363,7 @@ func (cc *ClientConn) handleQuery(sql string) (err error) {
 
 func (cc *ClientConn) handleFieldList(sql string) (err error) {
 	parts := strings.Split(sql, "\x00")
-	wildCard := ""
-	if len(parts) == 2 {
-		wildCard = parts[1]
-	}
-	columns, err := cc.ctx.FieldList(parts[0], wildCard)
+	columns, err := cc.ctx.FieldList(parts[0])
 	if err != nil {
 		return
 	}

--- a/server/driver.go
+++ b/server/driver.go
@@ -17,7 +17,7 @@ type IContext interface {
 	Execute(sql string) (*ResultSet, error)
 	Prepare(sql string) (statement IStatement, columns, params []*ColumnInfo, err error)
 	GetStatement(stmtId int) IStatement
-	FieldList(tableName, wildCard string) (columns []*ColumnInfo, err error)
+	FieldList(tableName string) (columns []*ColumnInfo, err error)
 	Close() error
 }
 

--- a/server/driver_combo.go
+++ b/server/driver_combo.go
@@ -366,6 +366,6 @@ func (cc *ComboContext) GetStatement(stmtId int) IStatement {
 	return cc.stmts[stmtId]
 }
 
-func (cc *ComboContext) FieldList(tableName, wildCard string) (columns []*ColumnInfo, err error) {
-	return cc.mc.FieldList(tableName, wildCard)
+func (cc *ComboContext) FieldList(tableName string) (columns []*ColumnInfo, err error) {
+	return cc.mc.FieldList(tableName)
 }

--- a/server/driver_mysql.go
+++ b/server/driver_mysql.go
@@ -501,8 +501,8 @@ func (mc *MysqlConn) Execute(command string) (*ResultSet, error) {
 	return mc.exec(command)
 }
 
-func (mc *MysqlConn) FieldList(table string, wildcard string) ([]*ColumnInfo, error) {
-	if err := mc.writeCommandStrStr(byte(ComFieldList), table, wildcard); err != nil {
+func (mc *MysqlConn) FieldList(table string) ([]*ColumnInfo, error) {
+	if err := mc.writeCommandStrStr(byte(ComFieldList), table, ""); err != nil {
 		return nil, err
 	}
 

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -167,7 +167,7 @@ func (tc *TidbContext) Close() (err error) {
 	return tc.session.Close()
 }
 
-func (tc *TidbContext) FieldList(table, wildCard string) (colums []*ColumnInfo, err error) {
+func (tc *TidbContext) FieldList(table string) (colums []*ColumnInfo, err error) {
 	rs, err := tc.Execute("SELECT * FROM " + table + " LIMIT 0")
 	if err != nil {
 		return

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -164,9 +164,7 @@ func (tc *TidbContext) Execute(sql string) (rs *ResultSet, err error) {
 }
 
 func (tc *TidbContext) Close() (err error) {
-	//TODO
-	//return tc.session.Close()
-	return
+	return tc.session.Close()
 }
 
 func (tc *TidbContext) FieldList(table, wildCard string) (colums []*ColumnInfo, err error) {


### PR DESCRIPTION
Table name sent from client is a null terminated string, use it directly in a sql will truncate the rest of the statement.
"SELECT \* FROM t LIMIT 0" will be truncated to "SELECT \* FROM t"
Results in full table scan when user connect to mp server with mysql client.
